### PR TITLE
Add custom strerror implementation

### DIFF
--- a/controve/common/BUILD
+++ b/controve/common/BUILD
@@ -1,0 +1,22 @@
+cc_library(
+    name = 'macros',
+    visibility = ['//visibility:public'],
+    hdrs = [ 'macros.hpp' ],
+)
+
+cc_library(
+    name = 'strerror',
+    visibility = ['//visibility:public'],
+    srcs = [ 'strerror.cpp' ],
+    hdrs = [ 'strerror.hpp' ],
+)
+
+cc_test(
+    name = 'test_strerror',
+    srcs = [ 'test_strerror.cpp' ],
+    size = 'small',
+    deps = [
+        ':strerror',
+        '//controve/tests:googletest',
+    ],
+)

--- a/controve/common/strerror.cpp
+++ b/controve/common/strerror.cpp
@@ -1,0 +1,39 @@
+#include "controve/common/strerror.hpp"
+
+#include <sys/types.h>
+#include <cstdio>
+#include <cassert>
+#include <cstring>
+
+namespace controve {
+namespace {
+
+const size_t buffer_size = 128;
+
+__attribute__((unused))
+char *controve_strerror_handle(__attribute__((unused)) int error, char *ret,
+    __attribute__((unused)) char *buffer) {
+  return ret;
+}
+
+__attribute__((unused))
+char* controve_strerror_handle(int error, int ret, char* buffer) {
+  if (ret != 0) {
+#ifndef NDEBUG
+    const int r =
+#endif
+      snprintf(buffer, buffer_size, "Unknown error %d", error);
+    assert (r > 0);
+  }
+  return buffer;
+}
+
+}  // namespace
+
+const char *controve_strerror(int error) {
+  static thread_local char buffer[buffer_size];
+
+  return controve_strerror_handle(
+      error, strerror_r(error, buffer, sizeof(buffer)), buffer);
+}
+}  // namespace controve

--- a/controve/common/strerror.hpp
+++ b/controve/common/strerror.hpp
@@ -1,0 +1,25 @@
+#ifndef CONTROVE_COMMON_STRERROR_HPP_
+#define CONTROVE_COMMON_STRERROR_HPP_
+
+/// @file strerror.hpp
+/// @brief Thread-safe implemenation of the POSIX function strerror(3)
+/// @author Lee Mracek
+/// @bugs None
+///
+/// A short list of POSIX functions are not required to be thread-
+/// safe. Unfortunately, we need them to be thread-safe, so the ones that we
+/// use need to be rewritten. A full list can be found at
+/// http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_09_01
+
+namespace controve {
+
+/// @brief Custom implemenation of strerror(3) to be thread-safe
+/// Essentially this acts as a safe wrapper for strerror(3).
+///
+/// @param error the ERRNO reported from the command/OS
+/// @return A char* array containing the user-friendly form of the error 
+const char *controve_strerror(int error);
+
+}  // namespace controve
+
+#endif  // CONTROVE_COMMON_STRERROR_HPP_

--- a/controve/common/test_strerror.cpp
+++ b/controve/common/test_strerror.cpp
@@ -1,0 +1,26 @@
+#include "controve/common/strerror.hpp"
+
+#include <cerrno>
+
+#include "gtest/gtest.h"
+
+namespace controve {
+namespace testing {
+
+TEST(StrerrorTest, Basic) {
+  EXPECT_STREQ("Argument list too long", controve::controve_strerror(E2BIG));
+  EXPECT_STREQ("Bad file descriptor", controve::controve_strerror(EBADF));
+  EXPECT_STREQ("Unknown error 4021", controve::controve_strerror(4021));
+}
+
+// Compare every single error number with the output of the system strerror
+// function.
+TEST(StrerrorTest, All) {
+  for (int i = 0; i < 4095; ++i) {
+    SCOPED_TRACE("iteration " + ::std::to_string(i));
+    EXPECT_STREQ(strerror(i), controve_strerror(i));
+  }
+}
+
+}
+}


### PR DESCRIPTION
This commit adds a custom implementation/wrapper around strerror which
will actually be thread-safe. The POSIX implementation is not required
to be thread-safe, and, in fact, is not.